### PR TITLE
SmartConnector: Ignore Conversion Comments

### DIFF
--- a/CheckPointObjects/CheckPointObjects.csproj
+++ b/CheckPointObjects/CheckPointObjects.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CheckPointObjects</RootNamespace>
     <AssemblyName>CheckPointObjects</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/CiscoMigration/CiscoMigration.csproj
+++ b/CiscoMigration/CiscoMigration.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CiscoMigration</RootNamespace>
     <AssemblyName>CiscoMigration</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/CommonUtils/CommonUtils.csproj
+++ b/CommonUtils/CommonUtils.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CommonUtils</RootNamespace>
     <AssemblyName>CommonUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/FortinetMigration/FortiGateMigration.csproj
+++ b/FortinetMigration/FortiGateMigration.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FortiGateMigration</RootNamespace>
     <AssemblyName>FortiGateMigration</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/JuniperMigration/JuniperMigration.csproj
+++ b/JuniperMigration/JuniperMigration.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>JuniperMigration</RootNamespace>
     <AssemblyName>JuniperMigration</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/MigrationBase/MigrationBase.csproj
+++ b/MigrationBase/MigrationBase.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MigrationBase</RootNamespace>
     <AssemblyName>MigrationBase</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/NetScreenMigration/NetScreenMigration.csproj
+++ b/NetScreenMigration/NetScreenMigration.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetScreenMigration</RootNamespace>
     <AssemblyName>NetScreenMigration</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/PaloAltoMigration/PaloAltoMigration.csproj
+++ b/PaloAltoMigration/PaloAltoMigration.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PaloAltoMigration</RootNamespace>
     <AssemblyName>PaloAltoMigration</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/SmartMove/App.config
+++ b/SmartMove/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/SmartMove/Properties/Resources.Designer.cs
+++ b/SmartMove/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace SmartMove.Properties
-{
-
-
+namespace SmartMove.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,36 +19,33 @@ namespace SmartMove.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
-
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("SmartMove.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.

--- a/SmartMove/Properties/Settings.Designer.cs
+++ b/SmartMove/Properties/Settings.Designer.cs
@@ -9,14 +9,14 @@
 //------------------------------------------------------------------------------
 
 namespace SmartMove.Properties {
-
-
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase{
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
+        
         public static Settings Default {
             get {
                 return defaultInstance;

--- a/SmartMove/SmartConnector/smartconnector.py
+++ b/SmartMove/SmartConnector/smartconnector.py
@@ -1029,8 +1029,15 @@ def addAccessRules(client, userRules, userLayerName, skipCleanUpRule, mergedNetw
             }
             if userRule['Action'] == 3:
                 payload["inline-layer"] = userRule['SubPolicyName']
-            if userRule['ConversionComments'].strip() != "":
-                payload["custom-fields"] = {"field-1": userRule['ConversionComments']}
+           
+            # Due to the custom-fields.field-[1-3] having a limit of 254 Characters, this is used as a workaround 
+            # Rule comments will stil be imported if they exist in userRule['Comments']
+            # The default value is False, so custom-fields will still be utilized. 
+            
+            isIgnoreConversionComments != True:
+                if userRule['ConversionComments'].strip() != "":
+                    payload["custom-fields"] = {"field-1": userRule['ConversionComments']}
+            # 
             addedRule = addUserObjectToServer(client, "add-access-rule", payload, changeName=False)
             if addedRule is not None:
                 printStatus(None, "REPORT: access rule is added")
@@ -1230,7 +1237,8 @@ args_parser.add_argument('-d', '--domain', default=None,
                          help="The name/uid of the domain you want to log into in an MDS environment.")
 args_parser.add_argument('--replace-from-global-first', default="false",
                          help="The argument indicates that SmartConnector should use 'Global' objects at first, by default it uses 'Local' objects. [true, false]")
-
+args_parser.add_argument('--ignore-conversion-comments', default="false",
+                         help="The argument indicates that SmartConnector should not add conversion comments into custom-fields [true, false]")
 args = args_parser.parse_args()
 
 file_name_log = "smartconnector"
@@ -1267,11 +1275,23 @@ elif args.replace_from_global_first.lower() != "true" and args.replace_from_glob
                 "smartconnector.py: error: argument --replace-from-global-first: invalid boolean value: '" + args.replace_from_global_first + "'")
     print("")
     args_parser.print_help()
+elif args.ignore_conversion_comments.lower() != "true" and args.ignore_conversion_comments.lower() != "false":
+    print("")
+    printStatus(None, None,
+                "smartconnector.py: error: argument '--ignore-conversion-comments: invalid boolean value: '" + args.ignore_conversion_comments + "'")
+    print("")
+    args_parser.print_help()
+
 else:
     if args.replace_from_global_first.lower() == "true":
         isReplaceFromGlobalFirst = True
     elif args.replace_from_global_first.lower() == "false":
         isReplaceFromGlobalFirst = False
+    if args.ignore_conversion_comments.lower() == "true":
+        isIgnoreConversionComments = True
+    else:
+       isIgnoreConversionComments = False
+
     printStatus(None, "Input arguments:")
     printStatus(None, "root flag is set" if args.root else "root flag is not set")
     printStatus(None, "management: " + args.management)
@@ -1284,6 +1304,7 @@ else:
     printStatus(None, "file: " + args.file)
     printStatus(None, "threshold: " + str(args.threshold))
     printStatus(None, "replace-from-global-first: " + str(isReplaceFromGlobalFirst))
+    printStatus(None, "ignore-conversion-comments: " + str(isIgnoreConversionComments))
     printStatus(None, "===========================================")
     printStatus(None, "reading and parsing processes are started for JSON file: " + args.file)
     with open(args.file) as json_file:

--- a/SmartMove/SmartConnector/smartconnector.py
+++ b/SmartMove/SmartConnector/smartconnector.py
@@ -1030,14 +1030,21 @@ def addAccessRules(client, userRules, userLayerName, skipCleanUpRule, mergedNetw
             if userRule['Action'] == 3:
                 payload["inline-layer"] = userRule['SubPolicyName']
            
-            # Due to the custom-fields.field-[1-3] having a limit of 254 Characters, this is used as a workaround 
+           # Due to the custom-fields.field-[1-3] having a limit of 254 Characters, this is used as a workaround
             # Rule comments will stil be imported if they exist in userRule['Comments']
-            # The default value is False, so custom-fields will still be utilized. 
-            
-            isIgnoreConversionComments != True:
+            # The default value is False, so custom-fields will still be utilized.
+            #
+            # If the Conversion Comments is > 150, then we should trim it.
+            # This matches the behavior in CheckPointObjects/CLIScriptBuilder.cs
+            #
+            if isIgnoreConversionComments != True:
                 if userRule['ConversionComments'].strip() != "":
-                    payload["custom-fields"] = {"field-1": userRule['ConversionComments']}
-            # 
+                    if len(userRule['ConversionComments']) > 150:
+                        newConversionComment = (userRule['ConversionComments'][:147] +'...')
+                        payload["custom-fields"] = {"field-1": newConversionComment}
+                    else:
+                        payload["custom-fields"] = {"field-1": userRule['ConversionComments']}
+            #
             addedRule = addUserObjectToServer(client, "add-access-rule", payload, changeName=False)
             if addedRule is not None:
                 printStatus(None, "REPORT: access rule is added")

--- a/SmartMove/SmartMove.csproj
+++ b/SmartMove/SmartMove.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SmartMove</RootNamespace>
     <AssemblyName>SmartMove</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -28,6 +28,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
The current behavior of smartconnector.py will add the conversion comments from SmartMove into custom-fields.field-1. 
This field has a length limitation of 254 characters and will cause rules to not import when running SmartConnector since the field length is not currently checked or truncated. 
This information is also in the conversion report, so some users might not want this data imported into their policies. 

This provides a --ignore-conversion-comments flag to simply skip adding them to the payload.  
There is a similar concern with the bash scripts that are generated, but this does not resolve that issue.